### PR TITLE
docs: add user types and future roadmap

### DIFF
--- a/Requirements.md
+++ b/Requirements.md
@@ -15,6 +15,20 @@ User registers account, after this he has the right to add info about current, f
 
 - First version "Copy hopper"
 
+## User Types
+
+### Current Users
+
+Individual copywriters who manage their own tasks and portfolios.
+
+### Planned Support for Agencies
+
+Agency accounts will coordinate multiple copywriters, delegating and tracking team assignments.
+
+### Long-Term Roadmap for Client Accounts
+
+Clients will eventually be able to register accounts, post tasks directly, and monitor progress through the platform.
+
 ## Entities
 
 Main entities in DB:


### PR DESCRIPTION
## Summary
- document current focus on individual copywriters
- outline planned agency accounts and long-term client task posting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae34880680832c9574c1a132596197