### PR TITLE
Add project waterfall plan with CI/CD details

### DIFF
--- a/detailed_plan.md
+++ b/detailed_plan.md
@@ -1,0 +1,91 @@
+# Detailed Task Breakdown
+
+This backlog divides the project into small tasks (1–3 days each) suitable for a Scrum board. Each task includes a clear description and a definition of done (DoD).
+
+## Environment & Tooling
+
+- **Task: Install core tooling** _(1 day)_
+  - **Description:** Install JDK 17+, Node.js 20+, Flutter 3+, Docker, and Git. Configure PATH variables. Verify installations with version commands.
+  - **DoD:** All tools installed and returning correct version numbers.
+- **Task: Configure shared development environment** _(2 days)_
+  - **Description:** Set up repository cloning, create `.env.example` with placeholder secrets, and document setup steps in README.
+  - **DoD:** Contributors can follow README to reproduce environment.
+
+## Backend (Kotlin/Gradle)
+
+- **Task: Scaffold backend project** _(1 day)_
+  - **Description:** Initialize Spring Boot/Ktor project with Gradle wrapper, basic application class, and health check endpoint.
+  - **DoD:** `./gradlew run` starts server and `/health` returns 200.
+- **Task: Configure database layer** _(2 days)_
+  - **Description:** Add ORM library (e.g., Exposed/Hibernate), define connection settings, and create migration framework.
+  - **DoD:** Application connects to local database; migration command creates schema.
+- **Task: Implement user authentication** _(3 days)_
+  - **Description:** Create user entity, registration/login endpoints, password hashing, and JWT token generation. Include unit tests.
+  - **DoD:** Auth endpoints tested; tokens grant access to protected route.
+- **Task: Add core domain CRUD API** _(3 days)_
+  - **Description:** Define domain models and REST endpoints (create/read/update/delete). Implement service layer and validation.
+  - **DoD:** CRUD endpoints pass unit and integration tests.
+- **Task: Write backend CI workflow** _(1 day)_
+  - **Description:** GitHub Action running `./gradlew test` and static analysis on pull requests, caching Gradle directories.
+  - **DoD:** Workflow file committed and passes on sample PR.
+
+## Frontend (Next.js)
+
+- **Task: Initialize Next.js project** _(1 day)_
+  - **Description:** Create Next.js app with TypeScript, ESLint, and Jest configured. Add placeholder page.
+  - **DoD:** `npm run dev` serves placeholder page; lint and tests succeed.
+- **Task: Build authentication pages** _(2 days)_
+  - **Description:** Implement login and registration forms, input validation, and API calls to backend auth endpoints.
+  - **DoD:** Users can sign in/out; Jest tests cover form logic.
+- **Task: Implement core feature pages** _(3 days)_
+  - **Description:** Create pages to list, create, edit, and delete domain objects. Use state management (e.g., React Query) and responsive styles.
+  - **DoD:** CRUD pages function against local backend and are covered by tests.
+- **Task: Frontend CI workflow** _(1 day)_
+  - **Description:** GitHub Action running `npm ci && npm run lint && npm test` with dependency caching.
+  - **DoD:** Workflow passes on sample PR.
+
+## Mobile (Flutter)
+
+- **Task: Bootstrap Flutter app** _(1 day)_
+  - **Description:** Create Flutter project with required packages (http, provider, etc.) and placeholder screen.
+  - **DoD:** `flutter run` shows placeholder; project analyzed with `flutter analyze`.
+- **Task: Implement authentication screens** _(2 days)_
+  - **Description:** Build login/registration UI, integrate with backend auth API, handle token storage.
+  - **DoD:** Users can authenticate; widget tests cover form validation.
+- **Task: Implement feature screens** _(3 days)_
+  - **Description:** Create list/detail/edit screens for domain objects with network error handling and local state management.
+  - **DoD:** Screens interact with backend; integration tests cover flows.
+- **Task: Mobile CI workflow** _(1 day)_
+  - **Description:** GitHub Action running `flutter test` on pull requests.
+  - **DoD:** Workflow passes on sample PR.
+
+## Database & Infrastructure
+
+- **Task: Write initial schema migrations** _(2 days)_
+  - **Description:** Define SQL/ORM migrations for core tables and seed data.
+  - **DoD:** Running migrations creates tables and seed records.
+- **Task: Docker Compose for local services** _(1 day)_
+  - **Description:** Create `docker-compose.yml` to run database, backend, and frontend locally with shared network.
+  - **DoD:** `docker-compose up` starts all services and they communicate.
+- **Task: Containerize applications** _(2 days)_
+  - **Description:** Write Dockerfiles for backend and frontend, configure multi-stage builds, and publish images to registry.
+  - **DoD:** Images build locally and run with expected behavior.
+- **Task: Define deployment pipeline** _(3 days)_
+  - **Description:** Create GitHub Actions workflow to build images on `main`, push to registry, run migrations, and deploy to staging environment.
+  - **DoD:** Workflow completes successfully and staging receives new images.
+
+## Quality Assurance
+
+- **Task: End-to-end test suite** _(3 days)_
+  - **Description:** Write automated tests exercising full stack using Docker Compose, verifying major user flows.
+  - **DoD:** Tests run in CI and pass against staging environment.
+- **Task: Monitoring & logging setup** _(2 days)_
+  - **Description:** Integrate logging framework and connect application metrics to monitoring service (e.g., Prometheus/Grafana).
+  - **DoD:** Logs and metrics visible in monitoring dashboard.
+
+## Documentation
+
+- **Task: Project documentation** _(1 day)_
+  - **Description:** Update README and create architecture/deployment guides.
+  - **DoD:** Docs merged and referenced by contributors.
+

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,69 @@
+# Project Plan
+
+## 1. Requirements & Analysis
+- Identify stakeholder goals and gather detailed feature requirements for backend, frontend, mobile and database components.
+- Define success metrics and non‑functional requirements (performance, security, scalability).
+- Produce an initial backlog and high‑level release schedule.
+
+## 2. System Design
+- **Architecture**: Choose a modular architecture separating the Kotlin/Gradle backend, Next.js frontend, Flutter mobile client and a relational database.
+- **API Design**: Specify REST endpoints and data contracts shared between clients.
+- **Database Design**: Model entities, relationships and migrations.
+- **Technology Decisions**: JDK 17+, Node.js 20+, Flutter 3+, Docker, GitHub Actions.
+
+## 3. Implementation
+1. **Environment setup**
+   - Install JDK, Node.js, Flutter SDK and Docker.
+   - Configure local `.env` files for secrets and API endpoints.
+   - Establish Git branching strategy and code review process.
+2. **Backend development**
+   - Scaffold Spring/Ktor modules, entities and repositories.
+   - Implement authentication, business logic and database migrations.
+   - Provide unit tests with JUnit and integration tests.
+3. **Frontend development**
+   - Implement Next.js pages, components and API calls.
+   - Add state management, routing and responsive styles.
+   - Write unit tests with Jest/React Testing Library and run ESLint.
+4. **Mobile development**
+   - Build Flutter screens and services that consume the backend API.
+   - Add platform integrations (notifications, storage, camera).
+   - Write widget and integration tests.
+5. **Database & infrastructure**
+   - Create schema migrations and seed data.
+   - Provide Docker Compose for local services (database, backend, frontend).
+
+## 4. Integration & Testing
+- Merge features into a develop branch and run full test suites.
+- Perform API contract tests between backend and clients.
+- Execute end‑to‑end tests against Docker Compose environment.
+- Collect code coverage and static analysis reports.
+
+### Continuous Integration
+- Use GitHub Actions triggered on pull requests.
+- Jobs:
+  - **Backend**: `./gradlew test` and static analysis.
+  - **Frontend**: `npm ci && npm run lint && npm test`.
+  - **Mobile**: `flutter test`.
+- Cache dependencies to speed up builds and upload artifacts for review.
+
+### Continuous Delivery
+- On merge to `main`:
+  - Build Docker images for backend and frontend and push to registry.
+  - Run database migrations.
+  - Deploy to staging environment using Docker Compose or Kubernetes.
+  - After manual approval, promote the same artifacts to production.
+- For mobile, trigger release workflows that sign and upload builds to the app stores.
+
+## 5. Deployment
+- **Staging**: Deploy automatically on successful CI using environment variables and test data. Run smoke tests.
+- **Production**: Deploy after approval, monitor with logging and metrics. Implement rollback strategy via previous container images.
+
+## 6. Maintenance & Iteration
+- Monitor errors, performance and user feedback.
+- Schedule periodic dependency updates and security scans.
+- Plan future iterations based on backlog and analytics.
+
+## 7. Documentation
+- Maintain up‑to‑date README and architectural decision records.
+- Document CI/CD pipelines and deployment procedures for onboarding.
+


### PR DESCRIPTION
## Summary
- add project plan outlining waterfall phases from requirements through maintenance
- document CI/CD pipelines for backend, frontend, mobile, and deployment strategy
- provide backlog of 1-3 day tasks for environment, backend, frontend, mobile, infra and QA

## Testing
- `./gradlew test` *(fails: No such file or directory)*
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68af253242b0832c961bb1077ad39608